### PR TITLE
Refactor speeches, #47

### DIFF
--- a/features/backend/calls.feature
+++ b/features/backend/calls.feature
@@ -23,7 +23,7 @@ Background:
         | organizer   | ru_RU  |
         | organizer2  | de_DE  |
     And following "Speech":
-        | ref     | title                | description                            | language | events       |
+        | ref     | title                | description                            | language | event        |
         | speech  | symfony propagation  | world symfony expansion                | ru       | event        |
         | speech2 | php servers piece    | php most popular language              | en       | event        |
         | speech3 | doctrine must have   | what you docrtine project should have  | en       | event        |

--- a/features/backend/events.feature
+++ b/features/backend/events.feature
@@ -26,7 +26,7 @@ Background:
         | organizer   | ru_RU  |
         | organizer2  | de_DE  |
     And following "Speech":
-        | ref     | title                | description                            | language | events       |
+        | ref     | title                | description                            | language | event        |
         | speech  | symfony propagation  | world symfony expansion                | ru       | event        |
         | speech2 | php servers piece    | php most popular language              | en       | event        |
         | speech3 | doctrine must have   | what you docrtine project should have  | en       | event        |

--- a/features/backend/organizers.feature
+++ b/features/backend/organizers.feature
@@ -23,7 +23,7 @@ Background:
         | organizer   | ru_RU  |
         | organizer2  | de_DE  |
     And following "Speech":
-        | ref     | title                | description                            | language | events       |
+        | ref     | title                | description                            | language | event        |
         | speech  | symfony propagation  | world symfony expansion                | ru       | event        |
         | speech2 | php servers piece    | php most popular language              | en       | event        |
         | speech3 | doctrine must have   | what you docrtine project should have  | en       | event        |

--- a/features/backend/schedule.feature
+++ b/features/backend/schedule.feature
@@ -23,7 +23,7 @@ Background:
         | organizer   | ru_RU  |
         | organizer2  | de_DE  |
     And following "Speech":
-        | ref     | title                | description                            | language | events       |
+        | ref     | title                | description                            | language | event        |
         | speech  | symfony propagation  | world symfony expansion                | ru       | event        |
         | speech2 | php servers piece    | php most popular language              | en       | event        |
         | speech3 | doctrine must have   | what you docrtine project should have  | en       | event        |

--- a/features/backend/speakers.feature
+++ b/features/backend/speakers.feature
@@ -23,7 +23,7 @@ Background:
         | organizer   | ru_RU  |
         | organizer2  | de_DE  |
     And following "Speech":
-        | ref     | title                | description                            | language | events       |
+        | ref     | title                | description                            | language | event        |
         | speech  | symfony propagation  | world symfony expansion                | ru       | event        |
         | speech2 | php servers piece    | php most popular language              | en       | event        |
         | speech3 | doctrine must have   | what you docrtine project should have  | en       | event        |

--- a/features/backend/speeches.feature
+++ b/features/backend/speeches.feature
@@ -23,7 +23,7 @@ Background:
         | organizer   | ru_RU  |
         | organizer2  | de_DE  |
     And following "Speech":
-        | ref     | title                | description                            | language | events       |
+        | ref     | title                | description                            | language | event        |
         | speech  | symfony propagation  | world symfony expansion                | ru       | event        |
         | speech2 | php servers piece    | php most popular language              | en       | event        |
         | speech3 | doctrine must have   | what you docrtine project should have  | en       | event        |
@@ -94,13 +94,10 @@ Scenario: Admin should have access to the speeches manage
     When I click "Speeches"
     Then I wait for a form
     Then I should see "Add speech"
-    And I should see the row containing "1;Alex Demchenko;ru /  symfony propagation;My event"
-    And I should see the row containing "2;Phill Pilow;en /  php servers piece;My event"
-    And I should see the row containing "3;Phill Pilow;en /  doctrine must have;My event"
-    And I should see the row containing "4;Alex Demchenko;en /  symfony propagation2;His event"
-    And I should see the row containing "5;Phill Pilow;en /  php servers piece2;His event"
-    And I should see the row containing "6;Phill Pilow;en /  doctrine must have2;His event"
-    When I click "Edit" on the row containing "6;Phill Pilow;en /  doctrine must have2;His event"
+    And I should see the row containing "4;Alex Demchenko;en / symfony propagation2"
+    And I should see the row containing "5;Phill Pilow;en / php servers piece2"
+    And I should see the row containing "6;Phill Pilow;en / doctrine must have2"
+    When I click "Edit" on the row containing "6;Phill Pilow;en / doctrine must have2"
     Then I wait for a form
     Then I should see "Edit speech"
 
@@ -116,12 +113,12 @@ Scenario: Admin should have able to add speeches
     And I fill in "Title" with "Test speech"
     And I select "Russian" from "Speech language"
     And I fill in "Description" with "Test description"
-    And I check "My event"
+    And I check "His event"
     And I select "Alex Demchenko" from "Speaker"
     And I press "Add"
     Then I wait for a form
     Then I should see "Speech Test speech added."
-    Then I should see the row containing "7;Alex Demchenko;ru /  Test speech;My event"
+    Then I should see the row containing "7;Alex Demchenko;ru / Test speech"
 
 @javascript
 Scenario: Admin should have able to update speeches settings
@@ -129,15 +126,15 @@ Scenario: Admin should have able to update speeches settings
     When I click "Speeches"
     Then I wait for a form
     Then I should see "Add speech"
-    And I should see the row containing "6;Phill Pilow;en /  doctrine must have2;His event"
-    When I click "Edit" on the row containing "6;Phill Pilow;en /  doctrine must have2;His event"
+    And I should see the row containing "6;Phill Pilow;en / doctrine must have2"
+    When I click "Edit" on the row containing "6;Phill Pilow;en / doctrine must have2"
     Then I wait for a form
     Then I should see "Edit speech"
     And I select "Russian" from "Speech language"
     And I press "Update"
     Then I wait for a form
     Then I should see "Speech doctrine must have2 updated."
-    Then I should see the row containing "6;Phill Pilow;ru /  doctrine must have2;His event"
+    Then I should see the row containing "6;Phill Pilow;ru / doctrine must have2"
 
 @javascript
 Scenario: Admin should have delete to the speeches
@@ -145,12 +142,12 @@ Scenario: Admin should have delete to the speeches
     When I click "Speeches"
     Then I wait for a form
     Then I should see "Add speech"
-    And I should see the row containing "1;Alex Demchenko;ru /  symfony propagation;My event"
-    And I should see the row containing "2;Phill Pilow;en /  php servers piece;My event"
-    Then I delete the record with id "2"
+    And I should see the row containing "4;Alex Demchenko;en / symfony propagation2"
+    And I should see the row containing "6;Phill Pilow;en / doctrine must have2;"
+    Then I delete the record with id "6"
     Then I wait for a form
     Then I should see "Speech deleted."
-    Then I should not see the row containing "2;Phill Pilow;en /  php servers piece;My event"
+    Then I should not see the row containing "6;Phill Pilow;en / doctrine must have2;"
 
 @javascript
 Scenario: Admin should have able to update Deutsch speeches settings
@@ -158,8 +155,8 @@ Scenario: Admin should have able to update Deutsch speeches settings
     When I click "Speeches"
     Then I wait for a form
     Then I should see "Add speech"
-    And I should see the row containing "6;Phill Pilow;en /  doctrine must have2;His event"
-    When I click "Edit" on the row containing "6;Phill Pilow;en /  doctrine must have2;His event"
+    And I should see the row containing "6;Phill Pilow;en / doctrine must have2"
+    When I click "Edit" on the row containing "6;Phill Pilow;en / doctrine must have2"
     Then I wait for a form
     Then I should see "Edit speech"
     And I click "de"
@@ -168,4 +165,4 @@ Scenario: Admin should have able to update Deutsch speeches settings
     And I press "Update"
     Then I wait for a form
     Then I should see "Speech doctrine must have2 updated."
-    Then I should see the row containing "6;Phill Pilow;en /  doctrine must have2;His event"
+    Then I should see the row containing "6;Phill Pilow;en / doctrine must have2"

--- a/features/backend/sponsors.feature
+++ b/features/backend/sponsors.feature
@@ -23,7 +23,7 @@ Background:
         | organizer   | ru_RU  |
         | organizer2  | de_DE  |
     And following "Speech":
-        | ref     | title                | description                            | language | events       |
+        | ref     | title                | description                            | language | event        |
         | speech  | symfony propagation  | world symfony expansion                | ru       | event        |
         | speech2 | php servers piece    | php most popular language              | en       | event        |
         | speech3 | doctrine must have   | what you docrtine project should have  | en       | event        |

--- a/src/Event/EventBundle/Command/SpeechEventCommand.php
+++ b/src/Event/EventBundle/Command/SpeechEventCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Event\EventBundle\Command;
+
+use Event\EventBundle\Entity\Speech;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\ProgressBar;
+
+/**
+ * Class SpeechEventCommand
+ */
+class SpeechEventCommand extends ContainerAwareCommand
+{
+    const TYPE_WRITE  = 'w',
+          TYPE_READ  = 'r';
+
+    /**
+     * Configures the current command.
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('eventator:speech:event_migrate')
+            ->setDescription('Migrate speech events from old version to new');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $container = $this->getContainer();
+        $em = $container->get('doctrine.orm.entity_manager');
+        $speechRepository = $em->getRepository('EventEventBundle:Speech');
+        $eventRepository = $em->getRepository('EventEventBundle:Event');
+
+        $speeches = $speechRepository->findAll();
+        $output->writeln("<info>Starts recording speeches with events to a file</info>");
+        $progress = new ProgressBar($output, count($speeches));
+        $progress->start();
+
+        /**
+         * @var Speech $speech
+         */
+        foreach ($speeches as $speech) {
+            $event = $eventRepository->getEventBySpeechId($speech->getId());
+
+            if ($event) {
+                $speech->setEvent($event);
+                $em->persist($speech);
+                $em->flush();
+            }
+            $progress->advance();
+        }
+
+        $progress->finish();
+
+        $output->writeln("\n<info>Recording speeches with events to a file were finished</info>");
+    }
+}

--- a/src/Event/EventBundle/Controller/Backend/SpeechController.php
+++ b/src/Event/EventBundle/Controller/Backend/SpeechController.php
@@ -3,18 +3,71 @@
 namespace Event\EventBundle\Controller\Backend;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Event\EventBundle\Controller\Controller;
 use Event\EventBundle\Entity\Speech;
 use Event\EventBundle\Entity\Translation\SpeechTranslation;
 use Event\EventBundle\Form\Type\SpeechType;
 
+/**
+ * Class SpeechController
+ */
 class SpeechController extends Controller
 {
+    /**
+     * @return Response
+     */
     public function indexAction()
     {
         return $this->render('EventEventBundle:Backend/Speech:index.html.twig', array(
-            'speeches' => $this->getRepository('EventEventBundle:Speech')->findAll()
+            'events' => $this->getRepository('EventEventBundle:Event')->findBy([], ['id' => 'DESC']),
         ));
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return JsonResponse
+     */
+    public function ajaxSpeechesListAction(Request $request)
+    {
+        $start = $request->get('start');
+        $length = $request->get('length');
+        $searchQuery = $request->get('search')['value'];
+        $order = $request->get('order');
+        $eventId = $request->get('event');
+        if ($eventId) {
+            $event = $this->getRepository('EventEventBundle:Event')->find($eventId);
+        } else {
+            $event = $this->getEvent();
+        }
+
+
+        $speeches = $this->getRepository('EventEventBundle:Speech')->getSpeechesByParameters($event, $searchQuery, $order, $start, $length);
+        $speechesCount = $this->getRepository('EventEventBundle:Speech')->getSpeechesCountByParameters($event, $searchQuery);
+
+        $data = array_map(function (Speech $speech) {
+            $actions = [
+                'editUrl' => $this->generateUrl('backend_speech_edit', ['id' => $speech->getId()]),
+                'deleteUrl' => $this->generateUrl('backend_speech_delete', ['id' => $speech->getId()]),
+            ];
+
+            return [
+                $speech->getId(),
+                $speech->getSpeaker()->getFullName(),
+                $speech->getTitle(),
+                $actions,
+
+            ];
+        }, $speeches);
+
+        return new JsonResponse([
+            'draw'            => $request->get('draw') ? intval($request->get('draw')) : 0,
+            'recordsTotal'    => $speechesCount,
+            'recordsFiltered' => $speechesCount,
+            'data'            => $data,
+        ]);
     }
 
     public function manageAction(Request $request, $id = null)

--- a/src/Event/EventBundle/Controller/Backend/SpeechController.php
+++ b/src/Event/EventBundle/Controller/Backend/SpeechController.php
@@ -56,7 +56,7 @@ class SpeechController extends Controller
             return [
                 $speech->getId(),
                 $speech->getSpeaker()->getFullName(),
-                $speech->getTitle(),
+                $speech->getLanguage()."&nbsp;/&nbsp;".$speech->getTitle(),
                 $actions,
 
             ];

--- a/src/Event/EventBundle/Entity/Event.php
+++ b/src/Event/EventBundle/Entity/Event.php
@@ -226,9 +226,9 @@ class Event
     private $speakers;
 
     /**
-     * @var speeches
+     * @var Speech
      *
-     * @ORM\ManyToMany(targetEntity="Speech", mappedBy="events")
+     * @ORM\OneToMany(targetEntity="Speech", mappedBy="event", cascade={"all"})
      */
     private $speeches;
 

--- a/src/Event/EventBundle/Entity/Repository/EventRepository.php
+++ b/src/Event/EventBundle/Entity/Repository/EventRepository.php
@@ -36,4 +36,19 @@ class EventRepository extends EntityRepository
             ->getResult()
             ;
     }
+
+    /**
+     * @param integer $speechId
+     * @return array
+     */
+    public function getEventBySpeechId($speechId)
+    {
+        return $this->createQueryBuilder('e')
+            ->leftJoin('e.program', 'p')
+            ->leftJoin('p.speech', 's')
+            ->where('s.id = :speechId')
+            ->setParameter('speechId', $speechId)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
 }

--- a/src/Event/EventBundle/Entity/Repository/SpeechRepository.php
+++ b/src/Event/EventBundle/Entity/Repository/SpeechRepository.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Event\EventBundle\Entity\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
+use Event\EventBundle\Entity\Event;
+
+/**
+ * SpeechRepository
+ */
+class SpeechRepository extends EntityRepository
+{
+    /**
+     * @return array
+     */
+    public function getSpeechesIdsArray()
+    {
+        return $this->createQueryBuilder('s')
+            ->select('s.id')
+            ->getQuery()->getArrayResult();
+    }
+
+    /**
+     * @param Event   $event
+     * @param string  $searchQuery
+     * @param array   $order
+     * @param integer $start
+     * @param integer $length
+     *
+     * @return array
+     */
+    public function getSpeechesByParameters(Event $event, $searchQuery, $order, $start, $length)
+    {
+        $qb = $this ->createQueryBuilder('s')
+            ->innerJoin('s.speaker', 'ssp');
+
+        if (count($order)) {
+            for ($i = 0, $ien = count($order); $i < $ien; $i++) {
+                switch ($order[$i]['column']) {
+                    case '0':
+                        $qb->addOrderBy('s.id', $order[$i]['dir']);
+                        break;
+                    case '1':
+                        $qb->addOrderBy('ssp.firstName', $order[$i]['dir']);
+                        break;
+                    case '2':
+                        $qb->addOrderBy('s.title', $order[$i]['dir']);
+                        break;
+                }
+            }
+        }
+
+        $qb = $this->speechesQueryAddParams($qb, $event, $searchQuery);
+
+        $qb->setFirstResult($start)
+            ->setMaxResults($length);
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @param Event  $event
+     * @param string $searchQuery
+     *
+     * @return array
+     */
+    public function getSpeechesCountByParameters(Event $event, $searchQuery)
+    {
+        $qb = $this ->createQueryBuilder('s')
+            ->innerJoin('s.speaker', 'ssp')
+            ->select('COUNT(DISTINCT s.id)');
+
+        $qb = $this->speechesQueryAddParams($qb, $event, $searchQuery);
+
+        return $qb->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * @param Event        $event
+     * @param QueryBuilder $qb
+     * @param string       $searchQuery
+     *
+     * @return \Doctrine\ORM\QueryBuilder
+     */
+    protected function speechesQueryAddParams(QueryBuilder $qb, Event $event, $searchQuery)
+    {
+        if ($searchQuery != '') {
+            $qb->where($qb->expr()->like('LOWER(s.title)', ':query'))
+                ->orWhere($qb->expr()->like('LOWER(ssp.firstName)', ':query'))
+                ->orWhere($qb->expr()->like('LOWER(ssp.lastName)', ':query'));
+
+            $qb->setParameter('query', '%'.mb_strtolower(trim($searchQuery), mb_detect_encoding($searchQuery)).'%');
+        }
+
+        if ($event) {
+            $qb->andWhere('s.event = :event')
+                ->setParameter('event', $event);
+        }
+
+        return $qb;
+    }
+}

--- a/src/Event/EventBundle/Entity/Speech.php
+++ b/src/Event/EventBundle/Entity/Speech.php
@@ -11,7 +11,7 @@ use Event\EventBundle\Entity\Translation\Translation;
  * Speech
  *
  * @ORM\Table(name="ev_speech")
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="Event\EventBundle\Entity\Repository\SpeechRepository")
  */
 class Speech
 {
@@ -87,11 +87,12 @@ class Speech
     private $program;
 
     /**
-     * @var events
+     * @var Event
      *
-     * @ORM\ManyToMany(targetEntity="Event", inversedBy="speeches")
+     * @Assert\NotNull()
+     * @ORM\ManyToOne(targetEntity="Event", inversedBy="speeches")
      */
-    private $events;
+    private $event;
 
 
     public function __construct()
@@ -245,5 +246,29 @@ class Speech
     public function getVideo()
     {
         return $this->video;
+    }
+
+    /**
+     * Set event
+     *
+     * @param \Event\EventBundle\Entity\Event $event
+     *
+     * @return Speech
+     */
+    public function setEvent(Event $event = null)
+    {
+        $this->event = $event;
+
+        return $this;
+    }
+
+    /**
+     * Get event
+     *
+     * @return \Event\EventBundle\Entity\Event
+     */
+    public function getEvent()
+    {
+        return $this->event;
     }
 }

--- a/src/Event/EventBundle/Form/Type/SpeechType.php
+++ b/src/Event/EventBundle/Form/Type/SpeechType.php
@@ -23,11 +23,11 @@ class SpeechType extends AbstractType
                 'placeholder' => 'Choose Speaker'
             ])
             // @todo: implement dynamic relation between speaker/event/speech
-            ->add('events', EntityType::class, [
+            ->add('event', EntityType::class, [
                 'class' => 'EventEventBundle:Event',
                 'placeholder' => 'Choose Event',
                 'expanded' => true,
-                'multiple' => true,
+                'multiple' => false,
             ])
             ->add('title', TextType::class)
             ->add('language', LanguageType::class, [

--- a/src/Event/EventBundle/Resources/config/routing/backend.yml
+++ b/src/Event/EventBundle/Resources/config/routing/backend.yml
@@ -49,6 +49,13 @@ backend_speech:
     path:  /speeches
     defaults: { _controller: EventEventBundle:Backend/Speech:index }
 
+backend_speech_ajax_speeches_list:
+    path:     /speech/ajax-speeches-list
+    defaults: { _controller: EventEventBundle:Backend/Speech:ajaxSpeechesList }
+    methods: ['GET']
+    options:
+        expose: true
+
 backend_speech_add:
     path:  /speech/add
     defaults: { _controller: EventEventBundle:Backend/Speech:manage }

--- a/src/Event/EventBundle/Resources/public/css/call_for_paper/call_for_paper.css
+++ b/src/Event/EventBundle/Resources/public/css/call_for_paper/call_for_paper.css
@@ -2,10 +2,6 @@
     margin-top: 20px;
 }
 
-.events-list {
-    text-align: right;
-}
-
 #call-for-paper_length select, #select-event {
     width: auto;
 }

--- a/src/Event/EventBundle/Resources/public/css/program/program.css
+++ b/src/Event/EventBundle/Resources/public/css/program/program.css
@@ -1,7 +1,3 @@
-.events-list {
-    text-align: right;
-}
-
 #program_length select, #select-event {
     width: auto;
 }

--- a/src/Event/EventBundle/Resources/public/css/speech/speech.css
+++ b/src/Event/EventBundle/Resources/public/css/speech/speech.css
@@ -1,0 +1,12 @@
+#speeches_length select, #select-event {
+    width: auto;
+}
+
+#speeches_wrapper table.dataTable thead th,
+#speeches_wrapper table.dataTable thead td {
+    border-bottom: none;
+}
+
+#speeches_wrapper table.dataTable.no-footer {
+    border-bottom: 1px solid #ddd;
+}

--- a/src/Event/EventBundle/Resources/public/css/style.css
+++ b/src/Event/EventBundle/Resources/public/css/style.css
@@ -124,3 +124,7 @@ form input {
     text-align: center;
     font-size: 28px;
 }
+
+.events-list {
+    text-align: right;
+}

--- a/src/Event/EventBundle/Resources/public/js/speech/speech.js
+++ b/src/Event/EventBundle/Resources/public/js/speech/speech.js
@@ -1,0 +1,49 @@
+$(function() {
+    var $body = $('body');
+
+    /* speeches list table */
+    var dataTable = $('#speeches').DataTable({
+        processing: false,
+        serverSide: true,
+        lengthMenu: [50, 100, 200, 300],
+        order: [[0, 'desc']],
+        pagingType: 'full_numbers',
+        dom: "<'row'<'span3'l><'span6'f>r>t<'row'<'span3'i><'span6'p>>",
+        ajax: {
+            url: Routing.generate('backend_speech_ajax_speeches_list'),
+            data: function (d) {
+                d.event = $('#select-event').val();
+            }
+        },
+        language: {
+            lengthMenu: "_MENU_ records per page",
+            infoEmpty: '0 of 0 entries'
+        },
+        createdRow: function(row, data, index) {
+            $(row).attr('id', 'item-' + data[0]);
+        },
+        columnDefs: [
+            {searchable: false, orderable: true, targets: 0, width: '5%'},
+            {searchable: true, orderable: true, targets: 1, width: '25%'},
+            {searchable: false, orderable: true, targets: 2},
+            {searchable: false, orderable: false, targets: 3, width: '10%',
+                render: function(data, type, row) {
+                    return '\
+                        <div class="btn-group">\
+                            <a class="btn btn-small" href="' + data['editUrl'] + '"><i class="icon-edit"></i> Edit</a>\
+                            <a class="btn btn-small dropdown-toggle actions-' + row[0] + '" data-toggle="dropdown" href="#"><span class="caret"></span></a>\
+                            <ul class="dropdown-menu">\
+                                <li><a href="' + data['deleteUrl'] + '" class="delete-call" id="modal-confirm-' + row[0] + '"><i class="icon-trash"></i> Delete</a></li>\
+                            </ul>\
+                        </div>\
+                    ';
+                }
+            }
+        ]
+    });
+    /* end speeches list table */
+
+    $body.on('change', '#select-event', function() {
+        dataTable.ajax.reload();
+    });
+});

--- a/src/Event/EventBundle/Resources/views/Backend/CallForPaper/index.html.twig
+++ b/src/Event/EventBundle/Resources/views/Backend/CallForPaper/index.html.twig
@@ -10,18 +10,7 @@
         <div class="page-header">
             <div class="row">
                 <div class="span3"><h3>Calls For Paper</h3></div>
-                <div class="span6">
-                    <div class="events-list">
-                        <label>
-                            Event:
-                            <select id="select-event">
-                                {% for event in events %}
-                                    <option value="{{ event.id }}">{{ event.title }}</option>
-                                {% endfor %}
-                            </select>
-                        </label>
-                    </div>
-                </div>
+                {% include 'EventEventBundle:Backend:_events_select.html.twig' %}
             </div>
         </div>
 

--- a/src/Event/EventBundle/Resources/views/Backend/Program/index.html.twig
+++ b/src/Event/EventBundle/Resources/views/Backend/Program/index.html.twig
@@ -13,18 +13,7 @@
             <div class="span3">
                 <a href="{{ path('backend_program_add') }}" class="btn btn-small btn-success">Add an entry</a>
             </div>
-            <div class="span6">
-                <div class="events-list">
-                    <label>
-                        Event:
-                        <select id="select-event">
-                            {% for event in events %}
-                                <option value="{{ event.id }}">{{ event.title }}</option>
-                            {% endfor %}
-                        </select>
-                    </label>
-                </div>
-            </div>
+            {% include 'EventEventBundle:Backend:_events_select.html.twig' %}
         </div>
     </div>
 
@@ -45,7 +34,6 @@
 
 {% block data_tables_js %}
     <script src="{{ asset('bundles/eventevent/js/libs/DataTables/jquery.dataTables.min.js') }}"></script>
-    <script src="{{ asset('bundles/eventevent/js/functions.js') }}"></script>
     <script src="{{ asset('bundles/eventevent/js/confirm.js') }}"></script>
     <script src="{{ asset('bundles/eventevent/js/program/program.js') }}"></script>
 {% endblock %}

--- a/src/Event/EventBundle/Resources/views/Backend/Speech/index.html.twig
+++ b/src/Event/EventBundle/Resources/views/Backend/Speech/index.html.twig
@@ -1,10 +1,20 @@
 {% extends 'EventEventBundle:Backend:layout.html.twig' %}
 
+{% block data_tables_css %}
+    <link href="{{ asset('bundles/eventevent/css/libs/DataTables/css/jquery.dataTables.min.css') }}" rel="stylesheet" type="text/css">
+    <link href="{{ asset('bundles/eventevent/css/speech/speech.css') }}" rel="stylesheet" type="text/css">
+{% endblock %}
+
 {% block content %}
 <section>
     <div class="page-header">
         <h3>Event speeches</h3>
-        <a href="{{ path('backend_speech_add') }}" class="btn btn-small btn-success">Add speech</a>
+        <div class="row">
+            <div class="span3">
+                <a href="{{ path('backend_speech_add') }}" class="btn btn-small btn-success">Add speech</a>
+            </div>
+            {% include 'EventEventBundle:Backend:_events_select.html.twig' %}
+        </div>
     </div>
 
     <table class="table table-striped table-bordered" id="speeches">
@@ -13,69 +23,15 @@
                 <th>id</th>
                 <th>Speaker Name</th>
                 <th>Title</th>
-                <th>Events</th>
                 <th width="10%">Actions</th>
             </tr>
         </thead>
-        <tbody>
-        {% for speech in speeches %}
-            <tr>
-                <td>{{ speech.id }}</td>
-                <td><a href="{{ url('backend_speaker_edit', {'id': speech.speaker.id}) }}">{{ speech.speaker.fullName }}</a></td>
-                <td>
-                    {{ speech.language|default(app.request.locale) }}&nbsp;/&nbsp;
-                    <a href="{{ url('backend_speech_edit', {'id': speech.id}) }}">{{ speech.title }}</a>
-                </td>
-                <td>
-                    {% for event in speech.events %}
-                        {{ event ~ (not loop.last ? ', ' : '') }}
-                    {% endfor %}
-                </td>
-                <td>
-                    <div class="btn-group">
-                        <a class="btn btn-small" href="{{ url('backend_speech_edit', {'id': speech.id}) }}"><i class="icon-user"></i> Edit</a>
-                        <a class="btn btn-small dropdown-toggle" data-toggle="dropdown" href="#"><span class="caret"></span></a>
-                        <ul class="dropdown-menu">
-                            <li><a href="{{ url('backend_speech_delete', {'id': speech.id}) }}"><i class="icon-trash"></i> Delete</a></li>
-                        </ul>
-                    </div>
-                </td>
-            </tr>
-        {% else %}
-            <tr>
-                <td colspan="5">No speeches found.</td>
-            </tr>
-        {% endfor %}
-        </tbody>
     </table>
 </section>
 {% endblock %}
 
-{% block javascripts %}
-    {{ parent() }}
-
-    <script type="text/javascript">
-        $(document).ready(function() {
-            var elementsCount = '{{ speeches|length }}';
-
-            if ( 0 < elementsCount) {
-                $('#speeches').dataTable({
-                    "iDisplayLength": 50,
-                    "sDom": "<'row'<'span7'l><'span2'f>r>t<'row'<'span3'i><'span6'p>>",
-                    "sPaginationType": "bootstrap",
-                    "oLanguage": {
-                        "sLengthMenu": "_MENU_ records per page"
-                    },
-                    "aoColumns": [
-                        null,
-                        null,
-                        null,
-                        null,
-                        { "bSearchable": false, "bSortable": false }
-                    ],
-                    "aaSorting": [[0, 'desc']]
-                });
-            }
-        });
-    </script>
+{% block data_tables_js %}
+    <script src="{{ asset('bundles/eventevent/js/libs/DataTables/jquery.dataTables.min.js') }}"></script>
+    <script src="{{ asset('bundles/eventevent/js/confirm.js') }}"></script>
+    <script src="{{ asset('bundles/eventevent/js/speech/speech.js') }}"></script>
 {% endblock %}

--- a/src/Event/EventBundle/Resources/views/Backend/Speech/manage.html.twig
+++ b/src/Event/EventBundle/Resources/views/Backend/Speech/manage.html.twig
@@ -14,7 +14,7 @@
             <div class="tab-pane active" id="{{ app.request.locale }}">
                 {{ form_row(form.speaker) }}
                 <div class="well">
-                    {{ form_row(form.events) }}
+                    {{ form_row(form.event) }}
                 </div>
                 {{ form_row(form.title) }}
                 {{ form_row(form.language) }}

--- a/src/Event/EventBundle/Resources/views/Backend/_events_select.html.twig
+++ b/src/Event/EventBundle/Resources/views/Backend/_events_select.html.twig
@@ -1,0 +1,12 @@
+<div class="span6">
+    <div class="events-list">
+        <label>
+            Event:
+            <select id="select-event">
+                {% for event in events %}
+                    <option value="{{ event.id }}">{{ event.title }}</option>
+                {% endfor %}
+            </select>
+        </label>
+    </div>
+</div>

--- a/src/Event/EventBundle/Resources/views/Event/_speaker-modal.html.twig
+++ b/src/Event/EventBundle/Resources/views/Event/_speaker-modal.html.twig
@@ -48,7 +48,7 @@
                 <div class="row">
                     <div class="col-sm-12">
                         {% for speech in speaker.speeches %}
-                            {% if currentEvent in speech.events %}
+                            {% if currentEvent == speech.event %}
                                 <p><strong>{{ speech.title }}</strong> <small>({{ speech.language }})</small></p>
                                 <p>{{ speech.description }}</p>
                             {% endif %}


### PR DESCRIPTION
![eventator_speeches](https://cloud.githubusercontent.com/assets/2562776/16655220/0d2301c2-4462-11e6-8a97-1b0eed2e1cb0.png)

To migrate old speech events to new need to run console command after schema was updated:
`php app/console eventator:speech:event_migrate`